### PR TITLE
Add support for custom PPAs.

### DIFF
--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -113,8 +113,13 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('output_filename')
     parser.add_argument('--customisation-script', dest='custom_script')
-    parser.add_argument('--ppa', dest='ppa')
-    parser.add_argument('--ppa-key', dest='ppa_key')
+    parser.add_argument('--ppa', dest='ppa', help='The URL of a PPA to inject '
+                        'in the build chroot. This can be either a '
+                        'ppa:<user>/<ppa> short URL or an https:// URL in the '
+                        'case of private PPAs.')
+    parser.add_argument('--ppa-key', dest='ppa_key', help='The GPG key ID '
+                        'with which the passed PPA was signed. This is only '
+                        'needed for private (https://) PPAs.')
     args = parser.parse_args()
 
     _write_cloud_config(args.output_filename, ppa=args.ppa,

--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -47,10 +47,10 @@ write_files:
 """
 
 PRIVATE_PPA_TEMPLATE = """
-- chroot $CHROOT_ROOT apt install apt-transport-https
+- chroot $CHROOT_ROOT apt-get install -y apt-transport-https
 - "echo 'deb {ppa_url} xenial main' | tee $CHROOT_ROOT/etc/apt/sources.list.d/builder-extra-ppa.list"
 - "chroot $CHROOT_ROOT apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys {key_id}"
-- chroot $CHROOT_ROOT apt update
+- chroot $CHROOT_ROOT apt-get -y update
 """
 
 def _get_ppa_snippet(ppa, ppa_key=None):

--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -66,7 +66,7 @@ def _get_ppa_snippet(ppa, ppa_key=None):
         used for private PPAs.
     """
     conf = ""
-    if ppa.startswith("https://"):
+    if ppa.startswith("https://") and 'private-ppa' in ppa:
         # This is likely a private PPA. We need to:
         # 1. Make sure apt-transport-https is installed.
         # 2. Add the URL to sources.list
@@ -82,7 +82,7 @@ def _get_ppa_snippet(ppa, ppa_key=None):
         conf = '- chroot $CHROOT_ROOT add-apt-repository -y -u {}'.format(ppa)
     else:
         raise ValueError('The extra PPA url must be of the "ppa:foo/bar" form,'
-                         ' or be an "https:" URL pointing to a private PPA.')
+                         ' or be an "https://" URL pointing to a private PPA.')
     return conf
 
 

--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -61,6 +61,9 @@ def _get_ppa_snippet(ppa, ppa_key=None):
     :param ppa:
         The PPA URL. This should be either a "ppa:foo/bar" short form or a
         full https:// URL for private PPAs.
+    :param ppa_key:
+        The hexacecimal key ID used to sign the PPA's package. This is only
+        used for private PPAs.
     """
     conf = ""
     if ppa.startswith("https://"):
@@ -94,6 +97,13 @@ def _write_cloud_config(output_file, customisation_script=None, ppa=None,
         An (optional) path to a customisation script; this will be included as a
         chroot hook in the build environment before it starts, allowing
         modifications to the image contents to be made.
+    :param ppa:
+        An (optional) URL pointing to either a public (ppa:user/repo) or
+        private (https://user:pass@private-ppa.launchpad.net/...) PPA.
+    :param ppa_key:
+        The (optional) hexadecimal key ID used to sign the PPA. This is only
+        used if "ppa" points to a private PPA, and is ignored in every other
+        case.
     """
     ppa_snippet = ""
     if ppa is not None:

--- a/tests.py
+++ b/tests.py
@@ -18,15 +18,20 @@ class TestGetPPASnippet(object):
         expected = '- chroot $CHROOT_ROOT add-apt-repository -y -u ppa:foo/bar'
         assert result == expected
 
-    def test_private_ppa_no_key(self):
+    def test_https_not_private_ppa(self):
         with pytest.raises(ValueError):
             generate_build_config._get_ppa_snippet('https://blah')
 
+    def test_private_ppa_no_key(self):
+        with pytest.raises(ValueError):
+            generate_build_config._get_ppa_snippet(
+                'https://private-ppa.example.com')
+
     def test_private_ppa_with_key(self):
         result = generate_build_config._get_ppa_snippet(
-            'https://blah', 'DEADBEEF')
-        assert 'apt install apt-transport-https' in result
-        assert 'deb https://blah xenial main' in result
+            'https://private-ppa.example.com', 'DEADBEEF')
+        assert 'apt-get install -y apt-transport-https' in result
+        assert 'deb https://private-ppa.example.com xenial main' in result
         assert ('apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 '
                 '--recv-keys DEADBEEF' in result)
 

--- a/tests.py
+++ b/tests.py
@@ -7,6 +7,30 @@ import yaml
 import generate_build_config
 
 
+class TestGetPPASnippet(object):
+
+    def test_unknown_url(self):
+        with pytest.raises(ValueError):
+            generate_build_config._get_ppa_snippet('ftp://blah')
+
+    def test_public_ppa(self):
+        result = generate_build_config._get_ppa_snippet('ppa:foo/bar')
+        expected = '- chroot $CHROOT_ROOT add-apt-repository -y -u ppa:foo/bar'
+        assert result == expected
+
+    def test_private_ppa_no_key(self):
+        with pytest.raises(ValueError):
+            generate_build_config._get_ppa_snippet('https://blah')
+
+    def test_private_ppa_with_key(self):
+        result = generate_build_config._get_ppa_snippet(
+            'https://blah', 'DEADBEEF')
+        assert 'apt install apt-transport-https' in result
+        assert 'deb https://blah xenial main' in result
+        assert ('apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 '
+                '--recv-keys DEADBEEF' in result)
+
+
 class TestWriteCloudConfig(object):
 
     def test_writes_to_file(self, tmpdir):
@@ -34,6 +58,18 @@ class TestWriteCloudConfig(object):
         generate_build_config._write_cloud_config(output_file.strpath)
         cloud_config = yaml.load(output_file.open())
         assert 'write_files' not in cloud_config
+
+    def test_no_ppa_included_by_default(self, tmpdir):
+        output_file = tmpdir.join('output.yaml')
+        generate_build_config._write_cloud_config(output_file.strpath)
+        assert 'add-apt-repository' not in output_file.read()
+        assert 'apt-transport-https' not in output_file.read()
+
+    def test_ppa_snippet_included(self, tmpdir):
+        output_file = tmpdir.join('output.yaml')
+        generate_build_config._write_cloud_config(
+            output_file.strpath, ppa='ppa:foo/bar')
+        assert 'add-apt-repository -y -u ppa:foo/bar' in output_file.read()
 
 
 class TestWriteCloudConfigWithCustomisationScript(object):
@@ -117,26 +153,20 @@ class TestMain(object):
             generate_build_config.main()
         assert excinfo.value.code > 0
 
-    def test_main_passes_first_argument_to_write_cloud_config(self, mocker):
+    def test_main_passes_arguments_to_write_cloud_config(self, mocker):
         output_filename = 'output.yaml'
-        mocker.patch('sys.argv', ['ubuntu-standalone-builder.py',
-                                  output_filename])
-        write_cloud_config_mock = mocker.patch(
-            'generate_build_config._write_cloud_config')
-        generate_build_config.main()
-        assert [mocker.call(
-            output_filename, customisation_script=None, ppa=None)] == \
-            write_cloud_config_mock.call_args_list
-
-    def test_main_passes_customisation_script(self, mocker):
         customisation_script = 'script.sh'
+        ppa = 'ppa:foo/bar'
+        ppa_key = 'DEADBEEF'
         mocker.patch('sys.argv', ['ubuntu-standalone-builder.py',
-                                  'output.yaml', '--customisation-script',
-                                  customisation_script])
+                                  output_filename, '--customisation-script',
+                                  customisation_script, '--ppa', ppa,
+                                  '--ppa-key', ppa_key])
         write_cloud_config_mock = mocker.patch(
             'generate_build_config._write_cloud_config')
         generate_build_config.main()
-        assert [mocker.call(mocker.ANY,
+        assert [mocker.call(output_filename,
                             customisation_script=customisation_script,
-                            ppa=None)] == \
-            write_cloud_config_mock.call_args_list
+                            ppa=ppa,
+                            ppa_key=ppa_key)] == \
+                write_cloud_config_mock.call_args_list


### PR DESCRIPTION
This PR adds support for custom PPAs, both private and public.

A new --ppa-key parameter was added for the private PPA case, since "add-apt-repository" does not work for private PPAs.

To test private PPAs:
- Navigate to a private PPA in launchpad.
- Click "grant access" (right menu)
- Add access to yourself for a sufficient period of time.
- Navigate to https://launchpad.net/~/+archivesubscriptions . Expand the PPA you just granted yourself access for.
- Copy the URL (it contains a unique access token).
- Note the signing key ID (the second part of the "1024R/DEADBEEF" hex on that page, e.g. "DEADBEEF")
- Pass the URL using --ppa, and the key ID with --ppa-key.
- run a build
- assert that the PPA was added to the apt configuration.

To test public PPAs:
- simply pass the short "ppa:user/repo" as --ppa.
- run a build
- assert that the PPA was added to the apt configuration.