### PR TITLE
Use daily images for chroot base

### DIFF
--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -16,7 +16,7 @@ runcmd:
 - export CHROOT_ROOT=/home/ubuntu/build-$BUILD_ID/chroot-autobuild
 
 # Setup build chroot
-- wget http://cloud-images.ubuntu.com/releases/xenial/release/ubuntu-16.04-server-cloudimg-amd64-root.tar.xz -O /tmp/root.tar.xz
+- wget http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-root.tar.xz -O /tmp/root.tar.xz
 - mkdir -p $CHROOT_ROOT
 - tar -C $CHROOT_ROOT -x -f /tmp/root.tar.xz
 - mkdir $CHROOT_ROOT/build

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,7 @@ import base64
 import py
 import pytest
 import yaml
+from six.moves.urllib.parse import urlparse
 
 import generate_build_config
 
@@ -85,6 +86,17 @@ class TestWriteCloudConfig(object):
         assert 1 == len(wget_lines)
         assert (
             'ubuntu-16.04-server-cloudimg-amd64-root.tar.xz ' in wget_lines[0])
+
+    def test_latest_release_image_used(self, tmpdir):
+        output_file = tmpdir.join('output.yaml')
+        generate_build_config._write_cloud_config(
+            output_file.strpath, ppa='ppa:foo/bar')
+        wget_lines = [
+            line for line in output_file.readlines() if 'wget' in line]
+        assert 1 == len(wget_lines)
+        url = wget_lines[0].split()[2]
+        path = urlparse(url).path
+        assert 'release' == path.split('/')[3]
 
 
 def customisation_script_combinations():

--- a/tests.py
+++ b/tests.py
@@ -71,21 +71,21 @@ class TestWriteCloudConfig(object):
         assert 'add-apt-repository' not in output_file.read()
         assert 'apt-transport-https' not in output_file.read()
 
+    def _get_wget_line(self, output_file):
+        wget_lines = [ln for ln in output_file.readlines() if 'wget' in ln]
+        assert 1 == len(wget_lines)
+        return wget_lines[0]
+
     def test_daily_image_used(self, tmpdir):
         output_file = tmpdir.join('output.yaml')
         generate_build_config._write_cloud_config(output_file.strpath)
-        wget_lines = [
-            line for line in output_file.readlines() if 'wget' in line]
-        assert 1 == len(wget_lines)
-        assert 'xenial-server-cloudimg-amd64-root.tar.xz ' in wget_lines[0]
+        wget_line = self._get_wget_line(output_file)
+        assert 'xenial-server-cloudimg-amd64-root.tar.xz ' in wget_line
 
     def test_latest_daily_image_used(self, tmpdir):
         output_file = tmpdir.join('output.yaml')
         generate_build_config._write_cloud_config(output_file.strpath)
-        wget_lines = [
-            line for line in output_file.readlines() if 'wget' in line]
-        assert 1 == len(wget_lines)
-        url = wget_lines[0].split()[2]
+        url = self._get_wget_line(output_file).split()[2]
         path = urlparse(url).path
         assert 'current' == path.split('/')[2]
 

--- a/tests.py
+++ b/tests.py
@@ -77,17 +77,16 @@ class TestWriteCloudConfig(object):
             output_file.strpath, ppa='ppa:foo/bar')
         assert 'add-apt-repository -y -u ppa:foo/bar' in output_file.read()
 
-    def test_release_image_used(self, tmpdir):
+    def test_daily_image_used(self, tmpdir):
         output_file = tmpdir.join('output.yaml')
         generate_build_config._write_cloud_config(
             output_file.strpath, ppa='ppa:foo/bar')
         wget_lines = [
             line for line in output_file.readlines() if 'wget' in line]
         assert 1 == len(wget_lines)
-        assert (
-            'ubuntu-16.04-server-cloudimg-amd64-root.tar.xz ' in wget_lines[0])
+        assert 'xenial-server-cloudimg-amd64-root.tar.xz ' in wget_lines[0]
 
-    def test_latest_release_image_used(self, tmpdir):
+    def test_latest_daily_image_used(self, tmpdir):
         output_file = tmpdir.join('output.yaml')
         generate_build_config._write_cloud_config(
             output_file.strpath, ppa='ppa:foo/bar')
@@ -96,7 +95,7 @@ class TestWriteCloudConfig(object):
         assert 1 == len(wget_lines)
         url = wget_lines[0].split()[2]
         path = urlparse(url).path
-        assert 'release' == path.split('/')[3]
+        assert 'current' == path.split('/')[2]
 
 
 def customisation_script_combinations():

--- a/tests.py
+++ b/tests.py
@@ -76,6 +76,16 @@ class TestWriteCloudConfig(object):
             output_file.strpath, ppa='ppa:foo/bar')
         assert 'add-apt-repository -y -u ppa:foo/bar' in output_file.read()
 
+    def test_release_image_used(self, tmpdir):
+        output_file = tmpdir.join('output.yaml')
+        generate_build_config._write_cloud_config(
+            output_file.strpath, ppa='ppa:foo/bar')
+        wget_lines = [
+            line for line in output_file.readlines() if 'wget' in line]
+        assert 1 == len(wget_lines)
+        assert (
+            'ubuntu-16.04-server-cloudimg-amd64-root.tar.xz ' in wget_lines[0])
+
 
 def customisation_script_combinations():
     customisation_script_content = '#!/bin/sh\nchroot'

--- a/tests.py
+++ b/tests.py
@@ -71,16 +71,9 @@ class TestWriteCloudConfig(object):
         assert 'add-apt-repository' not in output_file.read()
         assert 'apt-transport-https' not in output_file.read()
 
-    def test_ppa_snippet_included(self, tmpdir):
-        output_file = tmpdir.join('output.yaml')
-        generate_build_config._write_cloud_config(
-            output_file.strpath, ppa='ppa:foo/bar')
-        assert 'add-apt-repository -y -u ppa:foo/bar' in output_file.read()
-
     def test_daily_image_used(self, tmpdir):
         output_file = tmpdir.join('output.yaml')
-        generate_build_config._write_cloud_config(
-            output_file.strpath, ppa='ppa:foo/bar')
+        generate_build_config._write_cloud_config(output_file.strpath)
         wget_lines = [
             line for line in output_file.readlines() if 'wget' in line]
         assert 1 == len(wget_lines)
@@ -88,14 +81,19 @@ class TestWriteCloudConfig(object):
 
     def test_latest_daily_image_used(self, tmpdir):
         output_file = tmpdir.join('output.yaml')
-        generate_build_config._write_cloud_config(
-            output_file.strpath, ppa='ppa:foo/bar')
+        generate_build_config._write_cloud_config(output_file.strpath)
         wget_lines = [
             line for line in output_file.readlines() if 'wget' in line]
         assert 1 == len(wget_lines)
         url = wget_lines[0].split()[2]
         path = urlparse(url).path
         assert 'current' == path.split('/')[2]
+
+    def test_ppa_snippet_included(self, tmpdir):
+        output_file = tmpdir.join('output.yaml')
+        generate_build_config._write_cloud_config(
+            output_file.strpath, ppa='ppa:foo/bar')
+        assert 'add-apt-repository -y -u ppa:foo/bar' in output_file.read()
 
 
 def customisation_script_combinations():

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps=
     pytest
     pytest-mock
     pyyaml
+    six
 commands=
     pytest tests.py
 


### PR DESCRIPTION
As we update the chroot before we use it, we will end up with all the packages in the daily image.  As such, using the release image just increases the amount of work we have to do when building an image.