### PR TITLE
Add setup and teardown hooks around the chroot content

### DIFF
--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -56,13 +56,7 @@ SETUP_CONTENT = b"""\
 mv /usr/sbin/grub-probe /usr/sbin/grub-probe.dist
 cat <<"PSUEDO_GRUB_PROBE" > /usr/sbin/grub-probe
 #!/bin/sh
-Usage() {
-   cat <<EOF
-Usage: euca-psuedo-grub-probe
-   this is a wrapper around grub-probe to provide the answers for an ec2 guest
-EOF
-}
-bad_Usage() { Usage 1>&2; fail "$@"; }
+bad_Usage() { echo "$@"; exit 1; }
 
 short_opts=""
 long_opts="device-map:,target:,device"

--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -54,7 +54,7 @@ PRIVATE_PPA_TEMPLATE = """
 SETUP_CONTENT = b"""\
 #!/bin/sh -eux
 mv /usr/sbin/grub-probe /usr/sbin/grub-probe.dist
-cat <<"PSUEDO_GRUB_PROBE" > /usr/sbin/grub-probe
+cat <<"PSEUDO_GRUB_PROBE" > /usr/sbin/grub-probe
 #!/bin/sh
 bad_Usage() { echo "$@"; exit 1; }
 
@@ -91,7 +91,7 @@ case "${target}:${device}:${arg}" in
    drive:*:/dev/sda*) echo "(hd0,1)";;
    fs_uuid:*:*) exit 1;;
 esac
-PSUEDO_GRUB_PROBE
+PSEUDO_GRUB_PROBE
 chmod +x /usr/sbin/grub-probe
 """  # noqa: E501
 


### PR DESCRIPTION
Currently, these are static and configure grub-probe so we can
successfully install kernels within the chroot hook.