### PR TITLE
Put smoke test output in {envdir}

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,5 +22,5 @@ whitelist_externals=sh
 deps=
     shyaml
 commands=
-    generate_build_config output.yaml
-    sh -c \'shyaml get-type runcmd < output.yaml \'
+    generate_build_config {envdir}/output.yaml
+    sh -c \'shyaml get-type runcmd < {envdir}/output.yaml \'


### PR DESCRIPTION
We don't want it crufting up our development tree or, worse, overwriting
files there.