### PR TITLE
Add --binary-hook-filter option

### DIFF
--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -227,6 +227,11 @@ def main():
                         help='A path to a script which will be run outside of'
                         'the image chroot, to modify the way the contents are'
                         ' packed in to image files.')
+    parser.add_argument('--binary-hook-filter',
+                        dest='binary_hook_filter',
+                        help='A glob which will be used to remove binary'
+                        ' hooks from within the build chroot.  If not'
+                        ' specified, no binary hooks will be removed.')
     parser.add_argument('--customisation-script', dest='custom_script',
                         help='A path to a script which will be run within'
                         ' the image chroot, to modify the content within the'
@@ -243,6 +248,7 @@ def main():
     _write_cloud_config(args.output_filename,
                         customisation_script=args.custom_script,
                         binary_customisation_script=args.binary_custom_script,
+                        binary_hook_filter=args.binary_hook_filter,
                         ppa=args.ppa,
                         ppa_key=args.ppa_key)
 

--- a/tests.py
+++ b/tests.py
@@ -92,6 +92,18 @@ class TestWriteCloudConfig(object):
         output_file = write_cloud_config_to_tmpfile(ppa='ppa:foo/bar')
         assert 'add-apt-repository -y -u ppa:foo/bar' in output_file.read()
 
+    def test_binary_hook_filter_included(self, write_cloud_config_to_tmpfile):
+        hook_filter = 'some*glob*'
+        output_file = write_cloud_config_to_tmpfile(
+            binary_hook_filter=hook_filter)
+        cloud_config = yaml.load(output_file.open())
+        for stanza in cloud_config['write_files']:
+            content = base64.b64decode(stanza['content']).decode('utf-8')
+            if '{}|9997*|9998*|9999*'.format(hook_filter) in content:
+                break
+        else:
+            pytest.fail('Binary hook filter not correctly included.')
+
 
 def customisation_script_combinations():
     customisation_script_content = '#!/bin/sh\n-- chroot --'

--- a/tests.py
+++ b/tests.py
@@ -294,6 +294,7 @@ class TestMain(object):
     def test_main_passes_arguments_to_write_cloud_config(self, mocker):
         output_filename = 'output.yaml'
         binary_customisation_script = 'binary.sh'
+        binary_hook_filter = 'binary*hook*'
         customisation_script = 'script.sh'
         ppa = 'ppa:foo/bar'
         ppa_key = 'DEADBEEF'
@@ -301,6 +302,8 @@ class TestMain(object):
                                   output_filename,
                                   '--binary-customisation-script',
                                   binary_customisation_script,
+                                  '--binary-hook-filter',
+                                  binary_hook_filter,
                                   '--customisation-script',
                                   customisation_script, '--ppa', ppa,
                                   '--ppa-key', ppa_key])
@@ -310,6 +313,7 @@ class TestMain(object):
         assert [mocker.call(
             output_filename,
             binary_customisation_script=binary_customisation_script,
+            binary_hook_filter=binary_hook_filter,
             customisation_script=customisation_script,
             ppa=ppa,
             ppa_key=ppa_key)] == write_cloud_config_mock.call_args_list


### PR DESCRIPTION
This allows us to exclude pre-existing binary hooks from running, which
can make iterating on image build much faster.