### PR TITLE
Configure PPAs before update-debian-chroot

### DIFF
--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -28,8 +28,8 @@ runcmd:
 
 # Perform the build
 - /home/ubuntu/launchpad-buildd/mount-chroot $BUILD_ID
-- /home/ubuntu/launchpad-buildd/update-debian-chroot $BUILD_ID
 {ppa_conf}
+- /home/ubuntu/launchpad-buildd/update-debian-chroot $BUILD_ID
 - /home/ubuntu/launchpad-buildd/buildlivefs --arch amd64 --project ubuntu-cpc --series xenial --build-id $BUILD_ID
 - /home/ubuntu/launchpad-buildd/umount-chroot $BUILD_ID
 - mkdir /home/ubuntu/images

--- a/tests.py
+++ b/tests.py
@@ -93,6 +93,13 @@ class TestWriteCloudConfig(object):
         output = write_cloud_config_in_memory(ppa='ppa:foo/bar')
         assert 'add-apt-repository -y -u ppa:foo/bar' in output
 
+    def test_ppa_snippet_included_before_update_debian_chroot(
+            self, write_cloud_config_in_memory):
+        ppa_string = 'ppa:foo/bar'
+        output = write_cloud_config_in_memory(ppa=ppa_string)
+        assert output.find('add-apt-repository -y -u {}'.format(ppa_string)) \
+            < output.find('update-debian-chroot')
+
     def test_binary_hook_filter_included(self, write_cloud_config_in_memory):
         hook_filter = 'some*glob*'
         output = write_cloud_config_in_memory(binary_hook_filter=hook_filter)


### PR DESCRIPTION
If there are packages that would be dist-upgrade'd in the PPA, this
ensures they are included.