### PR TITLE
Include a serial in the built images

### DIFF
--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -30,7 +30,7 @@ runcmd:
 - /home/ubuntu/launchpad-buildd/mount-chroot $BUILD_ID
 - /home/ubuntu/launchpad-buildd/update-debian-chroot $BUILD_ID
 {ppa_conf}
-- /home/ubuntu/launchpad-buildd/buildlivefs --arch amd64 --project ubuntu-cpc --series xenial --build-id $BUILD_ID
+- /home/ubuntu/launchpad-buildd/buildlivefs --arch amd64 --project ubuntu-cpc --series xenial --build-id $BUILD_ID --datestamp ubuntu-standalone-builder-$(date +%s)
 - /home/ubuntu/launchpad-buildd/umount-chroot $BUILD_ID
 - mkdir /home/ubuntu/images
 - mv $CHROOT_ROOT/build/livecd.ubuntu-cpc.* /home/ubuntu/images

--- a/tests.py
+++ b/tests.py
@@ -65,6 +65,13 @@ class TestWriteCloudConfig(object):
         assert '- export BUILD_ID=output' in \
             write_cloud_config_in_memory().splitlines()
 
+    def test_serial_includes_ubuntu_standalone_builder(
+            self, write_cloud_config_in_memory):
+        buildlivefs_line = [
+            line for line in write_cloud_config_in_memory().splitlines()
+            if 'buildlivefs' in line][0]
+        assert '--datestamp ubuntu-standalone-builder' in buildlivefs_line
+
     def test_write_files_not_included_by_default(
             self, write_cloud_config_in_memory):
         cloud_config = yaml.load(write_cloud_config_in_memory())


### PR DESCRIPTION
This will have the prefix "ubuntu-standalone-builder-", which should be
easy to distinguish from published, fully-supportable images.

Fixes #31.