### PR TITLE
Support passing ppa arguments into the image build as well

### DIFF
--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -135,7 +135,7 @@ def _get_ppa_list(ppa):
     elif ppa.startswith("ppa:"):
         # The simple case, we simply need to inject an "add-apt-repository"
         # command.
-        return '--extra-ppa {}'.format(ppa.strip('ppa:'))
+        return '--extra-ppa {}'.format(ppa[4:])
     else:
         raise ValueError('The extra PPA url must be of the "ppa:foo/bar" form,'
                          ' or be an "https://" URL pointing to a private PPA.')

--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -167,6 +167,9 @@ def _get_ppa_snippet(ppa, ppa_key=None):
     elif ppa.startswith("ppa:"):
         # The simple case, we simply need to inject an "add-apt-repository"
         # command.
+        # If the ppa option has a pin priority, strip this out; this is
+        # only supported for the target image, not the build chroot.
+        ppa = ppa.rstrip(':0123456789')
         conf = '- chroot $CHROOT_ROOT add-apt-repository -y -u {}'.format(ppa)
     else:
         raise ValueError('The extra PPA url must be of the "ppa:foo/bar" form,'

--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -164,7 +164,7 @@ def _get_ppa_snippet(ppa, ppa_key=None):
             raise ValueError("You must provide a --ppa-key parameter if using "
                              "a private PPA URL.")
         conf = PRIVATE_PPA_TEMPLATE.format(ppa_url=ppa, key_id=ppa_key)
-    elif ppa.startswith("ppa"):
+    elif ppa.startswith("ppa:"):
         # The simple case, we simply need to inject an "add-apt-repository"
         # command.
         conf = '- chroot $CHROOT_ROOT add-apt-repository -y -u {}'.format(ppa)


### PR DESCRIPTION
There are occasions when you want to support specifying a ppa to configure in the target image, not just in the build chroot.  This is a first pass at implementing this.

In Launchpad itself, these two concepts are kept separate.  The one is specified in terms of the archive that the image is built "in"; the other is EXTRA_PPAS that are passed into the buildlivefs command.  So by trying to use the single --ppa option for both we are conflating a bit.  Do we care?

Further limitations:
- If the ppa is a private ppa, do not pass it into the build.  This isn't supported by launchpad-buildd today.
- You may want more than one ppa.  For instance, we have some custom images that use one (private) ppa for the source of the build scripts, but want to configure a separate (public) in the target image.  I haven't implemented this yet as part of this branch, because it takes some thinking how we want to match up when we have a mix of --ppa and --ppa-key options on the commandline.