### PR TITLE
Add image ppa support

### DIFF
--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -254,13 +254,20 @@ def main():
     parser.add_argument('--homedir', dest='homedir', metavar='PATH',
                         help='The path within the image where the build should'
                         ' be done')
-    parser.add_argument('--ppa', dest='ppa', help='The URL of a PPA to inject '
-                        'in the build chroot. This can be either a '
-                        'ppa:<user>/<ppa> short URL or an https:// URL in the '
-                        'case of private PPAs.')
-    parser.add_argument('--ppa-key', dest='ppa_key', help='The GPG key ID '
-                        'with which the passed PPA was signed. This is only '
-                        'needed for private (https://) PPAs.')
+    parser.add_argument('--build-ppa', dest='build_ppa', help='The URL of a '
+                        'PPA to inject in the build chroot. This can be '
+                        'either a ppa:<user>/<ppa> short URL or an https:// '
+                        'URL in the case of private PPAs. Example: '
+                        '"ppa:foo/bar" or "https://user:password@host/ubuntu"')
+    parser.add_argument('--build-ppa-key', dest='build_ppa_key', help='The '
+                        'GPG key ID with which the passed build PPA was '
+                        'signed. This is only needed for private (https://) '
+                        'PPAs.')
+    parser.add_argument('--image-ppa', dest='image_ppa', help='The identifier '
+                        'for a public PPA to inject into the built image. '
+                        'Optionally this can specify an apt pin priority for '
+                        'the whole PPA. Example: "foo/bar:1001". Note the '
+                        'absence of "~".')
     args = parser.parse_args()
 
     _write_cloud_config(args.outfile,
@@ -268,8 +275,8 @@ def main():
                         customisation_script=args.custom_script,
                         binary_customisation_script=args.binary_custom_script,
                         binary_hook_filter=args.binary_hook_filter,
-                        ppa=args.ppa,
-                        ppa_key=args.ppa_key)
+                        ppa=args.build_ppa,
+                        ppa_key=args.build_ppa_key)
 
 
 if __name__ == '__main__':

--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -184,15 +184,19 @@ def _write_cloud_config(output_file, binary_customisation_script=None,
     :param homedir:
         An (optional) path to use for the build environment within the cloud
         instance.
-    :param ppa:
+    :param build_ppa:
         An (optional) URL pointing to either a public (ppa:user/repo) or
-        private (https://user:pass@private-ppa.launchpad.net/...) PPA.
-    :param ppa_key:
-        The (optional) hexadecimal key ID used to sign the PPA. This is only
-        used if "ppa" points to a private PPA, and is ignored in every other
-        case.
+        private (https://user:pass@private-ppa.launchpad.net/...) PPA. This
+        will be injected in the builder's chroot.
+    :param build_ppa_key:
+        The (optional) hexadecimal key ID used to sign the builder PPA. This
+        is only used if "build_ppa" points to a private PPA, and is ignored in
+        every other case.
     :param image_ppa:
-        FIXME
+        The identifier for a PPA to be injected inside the built image,
+        optionally with a pin-priority. Archives have a priority of 500 by
+        default, anything above this will take pinning precedence. Example:
+        foo/bar:1001
     """
     ppa_snippet = ""
     if build_ppa is not None:

--- a/tests.py
+++ b/tests.py
@@ -324,8 +324,8 @@ class TestMain(object):
                                   binary_hook_filter,
                                   '--customisation-script',
                                   customisation_script,
-                                  '--homedir', homedir, '--ppa', ppa,
-                                  '--ppa-key', ppa_key])
+                                  '--homedir', homedir, '--build-ppa', ppa,
+                                  '--build-ppa-key', ppa_key])
         write_cloud_config_mock = mocker.patch(
             'generate_build_config._write_cloud_config')
         generate_build_config.main()

--- a/tests.py
+++ b/tests.py
@@ -83,7 +83,7 @@ class TestWriteCloudConfig(object):
         cloud_config = yaml.load(write_cloud_config_in_memory())
         assert 'write_files' not in cloud_config
 
-    def test_no_ppa_included_by_default(self, write_cloud_config_in_memory):
+    def test_no_build_ppa_by_default(self, write_cloud_config_in_memory):
         content = write_cloud_config_in_memory()
         assert 'add-apt-repository' not in content
         assert 'apt-transport-https' not in content
@@ -102,16 +102,25 @@ class TestWriteCloudConfig(object):
         path = urlparse(url).path
         assert 'current' == path.split('/')[2]
 
-    def test_ppa_snippet_included(self, write_cloud_config_in_memory):
-        output = write_cloud_config_in_memory(ppa='ppa:foo/bar')
+    def test_build_ppa_snippet_included(self, write_cloud_config_in_memory):
+        output = write_cloud_config_in_memory(build_ppa='ppa:foo/bar')
         assert 'add-apt-repository -y -u ppa:foo/bar' in output
 
-    def test_ppa_snippet_included_before_update_debian_chroot(
+    def test_build_ppa_snippet_included_before_update_debian_chroot(
             self, write_cloud_config_in_memory):
         ppa_string = 'ppa:foo/bar'
-        output = write_cloud_config_in_memory(ppa=ppa_string)
+        output = write_cloud_config_in_memory(build_ppa=ppa_string)
         assert output.find('add-apt-repository -y -u {}'.format(ppa_string)) \
             < output.find('update-debian-chroot')
+
+    def test_image_ppa_not_by_default(self, write_cloud_config_in_memory):
+        content = write_cloud_config_in_memory()
+        assert '--extra-ppa' not in content
+
+    def test_image_ppa_added(self, write_cloud_config_in_memory):
+        image_ppa = 'foo/bar:1001'
+        content = write_cloud_config_in_memory(image_ppa=image_ppa)
+        assert '--extra-ppa {}'.format(image_ppa) in content
 
     def test_binary_hook_filter_included(self, write_cloud_config_in_memory):
         hook_filter = 'some*glob*'
@@ -314,8 +323,9 @@ class TestMain(object):
         binary_hook_filter = 'binary*hook*'
         customisation_script = 'script.sh'
         homedir = '/var/tmp'
-        ppa = 'ppa:foo/bar'
-        ppa_key = 'DEADBEEF'
+        build_ppa = 'ppa:foo/bar'
+        build_ppa_key = 'DEADBEEF'
+        image_ppa = 'foo/bar:1001'
         mocker.patch('sys.argv', ['ubuntu-standalone-builder.py',
                                   output_filename,
                                   '--binary-customisation-script',
@@ -324,8 +334,10 @@ class TestMain(object):
                                   binary_hook_filter,
                                   '--customisation-script',
                                   customisation_script,
-                                  '--homedir', homedir, '--build-ppa', ppa,
-                                  '--build-ppa-key', ppa_key])
+                                  '--homedir', homedir,
+                                  '--build-ppa', build_ppa,
+                                  '--build-ppa-key', build_ppa_key,
+                                  '--image-ppa', image_ppa])
         write_cloud_config_mock = mocker.patch(
             'generate_build_config._write_cloud_config')
         generate_build_config.main()
@@ -336,6 +348,7 @@ class TestMain(object):
             'binary_hook_filter': binary_hook_filter,
             'customisation_script': customisation_script,
             'homedir': homedir,
-            'ppa': ppa,
-            'ppa_key': ppa_key},) == call[1:]
+            'build_ppa': build_ppa,
+            'build_ppa_key': build_ppa_key,
+            'image_ppa': image_ppa},) == call[1:]
         assert output_filename == call[0][0].name


### PR DESCRIPTION
This branch allows users to inject a (single) PPA *in the image being built* rather than injecting a PPA in the image builder's chroot.

The parameters have been renamed to reflect this distinction.