### PR TITLE
Use squashfs for the builder chroot

### DIFF
--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -10,6 +10,7 @@ TEMPLATE = """\
 #cloud-config
 packages:
 - bzr
+- squashfs-tools
 runcmd:
 # Setup environment
 - export HOME={homedir}
@@ -17,9 +18,9 @@ runcmd:
 - export CHROOT_ROOT={homedir}/build-$BUILD_ID/chroot-autobuild
 
 # Setup build chroot
-- wget http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-root.tar.xz -O /tmp/root.tar.xz
+- wget http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64.squashfs -O /tmp/root.squashfs
 - mkdir -p $CHROOT_ROOT
-- tar -C $CHROOT_ROOT -x -f /tmp/root.tar.xz
+- unsquashfs -d $CHROOT_TAR /tmp/root.squashfs
 - mkdir $CHROOT_ROOT/build
 - rm $CHROOT_ROOT/etc/resolv.conf  # We need to write over this symlink
 

--- a/generate_build_config.py
+++ b/generate_build_config.py
@@ -20,7 +20,7 @@ runcmd:
 # Setup build chroot
 - wget http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64.squashfs -O /tmp/root.squashfs
 - mkdir -p $CHROOT_ROOT
-- unsquashfs -d $CHROOT_TAR /tmp/root.squashfs
+- unsquashfs -force -no-progress -dest $CHROOT_ROOT /tmp/root.squashfs
 - mkdir $CHROOT_ROOT/build
 - rm $CHROOT_ROOT/etc/resolv.conf  # We need to write over this symlink
 

--- a/tests.py
+++ b/tests.py
@@ -95,7 +95,7 @@ class TestWriteCloudConfig(object):
 
     def test_daily_image_used(self, write_cloud_config_in_memory):
         wget_line = self._get_wget_line(write_cloud_config_in_memory())
-        assert 'xenial-server-cloudimg-amd64-root.tar.xz ' in wget_line
+        assert 'xenial-server-cloudimg-amd64.squashfs ' in wget_line
 
     def test_latest_daily_image_used(self, write_cloud_config_in_memory):
         url = self._get_wget_line(write_cloud_config_in_memory()).split()[2]


### PR DESCRIPTION
A switch to the squashfs download from the root tarball will
result in a smaller download and make it easier for advanced
users to tweak the output to build releases newer than xenial.